### PR TITLE
added nocomments and verbatim passes

### DIFF
--- a/compare50/__main__.py
+++ b/compare50/__main__.py
@@ -117,7 +117,7 @@ class ListAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         indentation = " " * 4
         for pass_ in _data.Pass._get_all():
-            print(str(pass_.__name__))
+            print(str(pass_.__name__), f"(default: {'ON' if pass_.default else 'OFF'})")
             for line in textwrap.wrap(pass_.__doc__ or "No description provided", 80 - len(indentation)):
                 print("{}{}".format(indentation, line))
         parser.exit()
@@ -225,7 +225,8 @@ def main():
     parser.add_argument("-p", "--passes",
                         dest="passes",
                         nargs="+",
-                        default=[pass_.__name__ for pass_ in _data.Pass._get_all()],
+                        default=[pass_.__name__ for pass_ in _data.Pass._get_all()
+                                                if pass_.default],
                         help="Specify which passes to use. compare50 ranks only by the first pass, but will render views for every pass.")
     parser.add_argument("-i", "--include",
                         callback=submission_factory.include,

--- a/compare50/_data.py
+++ b/compare50/_data.py
@@ -43,6 +43,9 @@ class Pass(metaclass=_PassRegistry):
     """
     __register = False
 
+    # Whether or not the pass should be enabled by default
+    default = False
+
     @abc.abstractmethod
     def preprocessors(self):
         pass

--- a/compare50/passes.py
+++ b/compare50/passes.py
@@ -8,7 +8,7 @@ __all__ = ["structure", "exact", "misspellings"]
 
 class structure(Pass):
     """Compares code structure by removing whitespace and comments; normalizing variable names, string literals, and numeric literals; and then running the winnowing algorithm."""
-
+    default = True
     preprocessors = [preprocessors.strip_whitespace,
                      preprocessors.strip_comments,
                      preprocessors.normalize_identifiers,
@@ -20,26 +20,27 @@ class structure(Pass):
 
 class exact(Pass):
     """Removes all whitespace, then uses the winnowing algorithm to compare submissions."""
+    default = True
     preprocessors = [preprocessors.split_on_whitespace,
                      preprocessors.strip_whitespace]
-    comparator = comparators.Winnowing(k=25, t=35)
-
-class nocomments(Pass):
-    """Removes comments, but keeps whitespace, then uses the winnowing algorithm to compare submissions"""
-    preprocessors = [ preprocessors.split_on_whitespace, preprocessors.strip_comments ]
-    comparator = comparators.Winnowing(k=25, t=35)
-
-class verbatim(Pass):
-    """Removes nothing, not even whitespaces, then uses the winnowing algorithm to compare submissions"""
-    preprocessors = [ ]
     comparator = comparators.Winnowing(k=25, t=35)
 
 
 class misspellings(Pass):
     """Compares comments for identically misspelled English words."""
-
+    default = True
     preprocessors = [preprocessors.comments,
                      preprocessors.normalize_case,
                      preprocessors.words]
     comparator = comparators.Misspellings(resource_filename("compare50.comparators",
                                                             "english_dictionary.txt"))
+
+class nocomments(Pass):
+    """Removes comments, but keeps whitespace, then uses the winnowing algorithm to compare submissions"""
+    preprocessors = [preprocessors.split_on_whitespace, preprocessors.strip_comments]
+    comparator = comparators.Winnowing(k=25, t=35)
+
+class verbatim(Pass):
+    """Removes nothing, not even whitespace, then uses the winnowing algorithm to compare submissions"""
+    preprocessors = []
+    comparator = comparators.Winnowing(k=25, t=35)

--- a/compare50/passes.py
+++ b/compare50/passes.py
@@ -37,7 +37,7 @@ class misspellings(Pass):
 
 class nocomments(Pass):
     """Removes comments, but keeps whitespace, then uses the winnowing algorithm to compare submissions"""
-    preprocessors = [preprocessors.split_on_whitespace, preprocessors.strip_comments]
+    preprocessors = [preprocessors.strip_comments, preprocessors.split_on_whitespace]
     comparator = comparators.Winnowing(k=25, t=35)
 
 class verbatim(Pass):

--- a/compare50/passes.py
+++ b/compare50/passes.py
@@ -24,6 +24,16 @@ class exact(Pass):
                      preprocessors.strip_whitespace]
     comparator = comparators.Winnowing(k=25, t=35)
 
+class nocomments(Pass):
+    """Removes comments, but keeps whitespace, then uses the winnowing algorithm to compare submissions"""
+    preprocessors = [ preprocessors.split_on_whitespace, preprocessors.strip_comments ]
+    comparator = comparators.Winnowing(k=25, t=35)
+
+class verbatim(Pass):
+    """Removes nothing, not even whitespaces, then uses the winnowing algorithm to compare submissions"""
+    preprocessors = [ ]
+    comparator = comparators.Winnowing(k=25, t=35)
+
 
 class misspellings(Pass):
     """Compares comments for identically misspelled English words."""


### PR DESCRIPTION
nocomments pass strips comments but preserves whitespace.  verbatim preserves comments and whitespace (as opposed to exact that strips whitespace).  Preserving whitespace can be useful, especially in CS1 classes.