### PR TITLE
Fix `AttributeError` on python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ branches:
 install: pip install .
 script: python -m tests
 before_deploy: |
-  version="v$(compare50 --version | cut --delimiter ' ' --fields 2)"
-  if [ -z "$(git tag --list "$version")" ]; then \
+  export TRAVIS_TAG="v$(compare50 --version | cut --delimiter ' ' --fields 2)"
+  if [ -z "$(git tag --list "$TRAVIS_TAG")" ]; then \
       git config --local user.name "bot50"; \
       git config --local user.email "bot@cs50.harvard.edu"; \
-      git tag "$version"; \
+      git tag "$TRAVIS_TAG"; \
   fi
 deploy:
 - provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python: 3.6
 branches:
-  except: "/^v\\.\\d\\.\\d\\.\\d/"
+  except: /^v\d+\.\d+\.\d+/
 install: pip install .
 script: python -m tests
 before_deploy: |

--- a/compare50/__main__.py
+++ b/compare50/__main__.py
@@ -137,17 +137,6 @@ class IncludeExcludeAction(argparse.Action):
             self.callback(v)
 
 
-@attr.s(slots=True)
-class Preprocessor:
-    """Hack to ensure that composed preprocessor is serializable by Pickle."""
-    preprocessors = attr.ib()
-
-    def __call__(self, tokens):
-        for preprocessor in self.preprocessors:
-            tokens = preprocessor(tokens)
-        return tokens
-
-
 PROFILE = [ _api.compare
           , comparators.Winnowing.score
           , comparators.Winnowing.compare
@@ -283,7 +272,7 @@ def main():
         raise _api.Error("{} is not a pass, try one of these: {}"
                            .format(e.args[0], [c.__name__ for c in _data.Pass._get_all()]))
 
-    preprocessor = Preprocessor(passes[0].preprocessors)
+    preprocessor = _data.Preprocessor(passes[0].preprocessors)
 
     if args.profile:
         args.debug = True
@@ -334,7 +323,7 @@ def main():
         pass_to_results = {}
         for pass_ in passes:
             with _api.progress_bar(f"Comparing ({pass_.__name__})", disable=args.debug):
-                preprocessor = Preprocessor(pass_.preprocessors)
+                preprocessor = _data.Preprocessor(pass_.preprocessors)
                 for sub in itertools.chain(subs, archive_subs, ignored_subs):
                     object.__setattr__(sub, "preprocessor", preprocessor)
                 pass_to_results[pass_] = _api.compare(scores, ignored_files, pass_)

--- a/compare50/_api.py
+++ b/compare50/_api.py
@@ -3,7 +3,6 @@ import contextlib
 import heapq
 import io
 import itertools
-import multiprocessing
 import time
 
 import intervaltree

--- a/compare50/_data.py
+++ b/compare50/_data.py
@@ -209,6 +209,17 @@ class File:
         return tokens
 
 
+@attr.s(slots=True)
+class Preprocessor:
+    """Hack to ensure that composed preprocessor is serializable by Pickle."""
+    preprocessors = attr.ib()
+
+    def __call__(self, tokens):
+        for preprocessor in self.preprocessors:
+            tokens = preprocessor(tokens)
+        return tokens
+
+
 @attr.s(slots=True, frozen=True, repr=False)
 class Span:
     """

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(
     packages=find_packages(exclude=["tests"]),
     scripts=["bin/compare50"],
     url="https://github.com/cs50/compare50",
-    version="1.1.2",
+    version="1.1.3",
     include_package_data=True,
 )

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -2,7 +2,6 @@ import unittest
 import tempfile
 import os
 
-from compare50.__main__ import Preprocessor
 import compare50._data as data
 import compare50._api as api
 

--- a/tests/winnowing_tests.py
+++ b/tests/winnowing_tests.py
@@ -3,7 +3,6 @@ import tempfile
 import os
 import sys
 
-from compare50.__main__ import Preprocessor
 import compare50.comparators._winnowing as winnowing
 import compare50._data as data
 


### PR DESCRIPTION
Fixes https://github.com/cs50/compare50/issues/39 (tested on python 3.8.0 on OS X)

Still somewhat unsure what changed in 3.8. By the looks of things the `__main__` module refers to something different than `__main__.py` in the subprocesses in 3.8. That made it impossible to import `Preprocessor` that was defined in `__main__.py`. Moving `Preprocessor` to a module with a name, `_data.py`, fixes the issue.   