### PR TITLE
More performant utf8 checking

### DIFF
--- a/compare50/__main__.py
+++ b/compare50/__main__.py
@@ -99,7 +99,7 @@ class SubmissionFactory:
         This function reads in the file in increasingly large blocks so that it can error out early if necessary.
         """
         try:
-            with open(file_path) as f:
+            with open(file_path, encoding="utf8") as f:
                 blocksize = 64
                 while f.read(blocksize):
                     blocksize *= 2;

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(
     packages=find_packages(exclude=["tests"]),
     scripts=["bin/compare50"],
     url="https://github.com/cs50/compare50",
-    version="1.1.3",
+    version="1.1.4",
     include_package_data=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(
     packages=find_packages(exclude=["tests"]),
     scripts=["bin/compare50"],
     url="https://github.com/cs50/compare50",
-    version="1.1.4",
+    version="1.1.3",
     include_package_data=True,
 )


### PR DESCRIPTION
Previously, we checked if a file was valid utf8 by one `f.read()` call. Unfortunately, Python handles this by first reading the whole file in and then checking if it is invalid utf8. This means if you gave compare50 a 1GB file of random data, it would read all 1GB in even though the first few bytes might be enough to tell that it was invalid utf8.

This PR replaces the `f.read()` call by a loop that reads in the file chunk by chunk so that we can error out earlier if we find invalid utf8. The chunk size doubles on each iteration of the loop since the probability that the file is valid utf8 increases the more valid chunks we read. This allows us to have fewer `read` calls on valid files than a fixed-size chunk approach.