### PR TITLE
max_file_size + print how many / which files are excluded

### DIFF
--- a/compare50/__main__.py
+++ b/compare50/__main__.py
@@ -46,8 +46,8 @@ sys.excepthook = excepthook
 
 
 class SubmissionFactory:
-    def __init__(self, max_file_size=100):
-        self.max_file_size = max_file_size
+    def __init__(self):
+        self.max_file_size = 1024 * 1024
         self.patterns = []
         self.submissions = {}
 
@@ -355,6 +355,11 @@ def main():
                         metavar="MATCHES",
                         type=int,
                         help="number of matches to output")
+    parser.add_argument("--max-file-size",
+                        action="store",
+                        default=1024,
+                        type=int,
+                        help="maximum allowed file size in kilobytes (default 1024kB)")
     parser.add_argument("--profile",
                         action="store_true",
                         help="profile compare50 (development only, requires line_profiler, implies debug)")
@@ -369,10 +374,12 @@ def main():
 
     excepthook.verbose = args.verbose
 
+    # Set max file size in bytes
+    submission_factory.max_file_size = args.max_file_size * 1024
+
     for attrib in ("submissions", "archive", "distro"):
         # Expand all patterns found in args.{submissions,archive,distro}
         setattr(args, attrib, expand_patterns(getattr(args, attrib)))
-
 
     # Extract comparator and preprocessors from pass
     try:

--- a/compare50/__main__.py
+++ b/compare50/__main__.py
@@ -88,8 +88,8 @@ class SubmissionFactory:
         small, large = partition(decodable, lambda fp: (path / fp).stat().st_size <= self.max_file_size)
 
         return _data.Submission(path, sorted(small),
-                                large_files=large,
-                                undecodable_files=undecodable,
+                                large_files=sorted(large),
+                                undecodable_files=sorted(undecodable),
                                 preprocessor=preprocessor,
                                 is_archive=is_archive)
 

--- a/compare50/__main__.py
+++ b/compare50/__main__.py
@@ -46,7 +46,8 @@ sys.excepthook = excepthook
 
 
 class SubmissionFactory:
-    def __init__(self):
+    def __init__(self, max_file_size=100):
+        self.max_file_size = max_file_size
         self.patterns = []
         self.submissions = {}
 
@@ -61,7 +62,10 @@ class SubmissionFactory:
     def _get(self, path, preprocessor, is_archive=False):
         path = pathlib.Path(path)
 
+        # Ask lib50 which file(s) in path should be included
         if path.is_file():
+            # lib50.files operates on a directory
+            # So create a tempdir if the path is just a file
             with tempfile.TemporaryDirectory() as dir:
                 (pathlib.Path(dir) / path.name).touch()
                 included, excluded = lib50.files(self.patterns, root=dir)
@@ -69,12 +73,35 @@ class SubmissionFactory:
         else:
             included, excluded = lib50.files(self.patterns, require_tags=[], root=path)
 
-        decodable_files = sorted(file_path for file_path in included if self._is_valid_utf8(path / file_path))
+        # Filter out any non utf8 files
+        undecodable_files = []
+        decodable_files = []
+        for file_path in included:
+            if self._is_valid_utf8(path / file_path):
+                decodable_files.append(file_path)
+            else:
+                undecodable_files.append(file_path)
 
-        if not decodable_files:
+        # Filter out any large files (>self.max_file_size)
+        small_files = []
+        large_files = []
+        for file_path in decodable_files:
+            if (path / file_path).stat().st_size <= self.max_file_size:
+                small_files.append(file_path)
+            else:
+                large_files.append(file_path)
+
+        small_files = sorted(small_files)
+
+        # Error in case no files are left in the submission
+        if not small_files:
             raise _api.Error(f"Empty submission: {path}")
 
-        return _data.Submission(path, decodable_files, preprocessor=preprocessor, is_archive=is_archive)
+        return _data.Submission(path, small_files,
+                                large_files=large_files,
+                                undecodable_files=undecodable_files,
+                                preprocessor=preprocessor,
+                                is_archive=is_archive)
 
     def get_all(self, paths, preprocessor, is_archive=False):
         """
@@ -85,6 +112,7 @@ class SubmissionFactory:
         for sub_path in paths:
             try:
                 subs.add(self._get(sub_path, preprocessor, is_archive))
+            # Ignore empty submissions
             except _api.Error:
                 pass
             else:
@@ -187,12 +215,57 @@ class PluralDict(dict):
         raise KeyError(key)
 
 
-def print_stats(subs, archives, distro_files):
+def print_stats(subs, archives, distro_subs, distro_files, verbose=False):
     avg = round(sum(len(s.files) for s in itertools.chain(subs, archives)) / (len(subs) + len(archives)), 2)
     data = PluralDict(subs=len(subs), archives=len(archives), distro=len(distro_files), avg=avg)
     fmt = "Found {subs} submission{subs(s)}, {archives} archive submission{archives(s)}, and " \
           "{distro} distro file{distro(s)} with an average of {avg} file{avg(s)} per submission"
     termcolor.cprint(fmt.format_map(data), "yellow", attrs=["bold"])
+
+    did_print_warning = False
+
+    def get_large_files(subs):
+        return [file_path for sub in subs for file_path in sub.large_files]
+
+    large = get_large_files(subs)
+    large_archive = get_large_files(archives)
+    large_distro = get_large_files(distro_subs)
+
+    # Warn about excluded large files
+    if large or large_archive or large_distro:
+        data = PluralDict(subs=len(large),
+                          archives=len(large_archive),
+                          distro=len(large_distro),
+                          total=len(large) + len(large_archive) + len(large_distro))
+        fmt = "Excluded {total} large file{total(s)}: {subs} in submissions, " \
+              "{archives} in archives, {distro} in distro"
+        termcolor.cprint(fmt.format_map(data), "yellow", attrs=["bold"])
+        termcolor.cprint("  Consider increasing --max-file-size if these files should be included,",
+                         "yellow", attrs=["bold"])
+        did_print_warning = True
+
+    def get_undecodable_files(subs):
+        return [file_path for sub in subs for file_path in sub.undecodable_files]
+
+    undecodable = get_undecodable_files(subs)
+    undecodable_archive = get_undecodable_files(archives)
+    undecodable_distro = get_undecodable_files(distro_subs)
+
+    # Warn about undecodable (non utf-8) files
+    if undecodable or undecodable_archive or undecodable_distro:
+        data = PluralDict(subs=len(undecodable),
+                          archives=len(undecodable_archive),
+                          distro=len(undecodable_distro),
+                          total=len(undecodable) + len(undecodable_archive) + len(undecodable_distro))
+        fmt = "Excluded {total} non utf-8 file{total(s)}: {subs} in submissions, " \
+              "{archives} in archives, {distro} in distro"
+        termcolor.cprint(fmt.format_map(data), "yellow", attrs=["bold"])
+        did_print_warning = True
+
+    # Print suggestion to run with --verbose if any files are excluded
+    if not verbose and did_print_warning:
+        termcolor.cprint("Rerun with --verbose to see which files are excluded",
+                         "yellow", attrs=["bold"])
 
 
 def expand_patterns(patterns):
@@ -319,7 +392,7 @@ def main():
             if len(subs) + len(archive_subs) < 2:
                 raise _api.Error("At least two non-empty submissions are required for a comparison.")
 
-        print_stats(subs, archive_subs, ignored_files)
+        print_stats(subs, archive_subs, ignored_subs, ignored_files)
 
         with _api.progress_bar(f"Scoring ({passes[0].__name__})", disable=args.debug) as bar:
             # Cross compare and rank all submissions, keep only top `n`

--- a/compare50/_data.py
+++ b/compare50/_data.py
@@ -116,6 +116,8 @@ class Submission:
 
     path = attr.ib(converter=pathlib.Path, cmp=False)
     files = attr.ib(cmp=False)
+    large_files = attr.ib(default=attr.Factory(list), cmp=False, repr=False)
+    undecodable_files = attr.ib(default=attr.Factory(list), cmp=False, repr=False)
     preprocessor = attr.ib(default=lambda tokens: tokens, cmp=False, repr=False)
     is_archive = attr.ib(default=False, cmp=False)
     id = attr.ib(init=False)

--- a/compare50/_data.py
+++ b/compare50/_data.py
@@ -116,8 +116,8 @@ class Submission:
 
     path = attr.ib(converter=pathlib.Path, cmp=False)
     files = attr.ib(cmp=False)
-    large_files = attr.ib(default=attr.Factory(tuple), converter=lambda fs: tuple(pathlib.Path(f) for f in fs), cmp=False, repr=False)
-    undecodable_files = attr.ib(default=attr.Factory(tuple), converter=lambda fs: tuple(pathlib.Path(f) for f in fs), cmp=False, repr=False)
+    large_files = attr.ib(factory=tuple, converter=lambda fs: tuple(pathlib.Path(f) for f in fs), cmp=False, repr=False)
+    undecodable_files = attr.ib(factory=tuple, converter=lambda fs: tuple(pathlib.Path(f) for f in fs), cmp=False, repr=False)
     preprocessor = attr.ib(default=lambda tokens: tokens, cmp=False, repr=False)
     is_archive = attr.ib(default=False, cmp=False)
     id = attr.ib(init=False)

--- a/compare50/_data.py
+++ b/compare50/_data.py
@@ -112,12 +112,12 @@ class Submission:
     Represents a single submission. Submissions may either be single files or
     directories containing many files.
     """
-    _store = IdStore(key=lambda sub: (sub.path, sub.files))
+    _store = IdStore(key=lambda sub: (sub.path, sub.files, sub.large_files, sub.undecodable_files))
 
     path = attr.ib(converter=pathlib.Path, cmp=False)
     files = attr.ib(cmp=False)
-    large_files = attr.ib(default=attr.Factory(list), cmp=False, repr=False)
-    undecodable_files = attr.ib(default=attr.Factory(list), cmp=False, repr=False)
+    large_files = attr.ib(default=attr.Factory(tuple), cmp=False, repr=False)
+    undecodable_files = attr.ib(default=attr.Factory(tuple), cmp=False, repr=False)
     preprocessor = attr.ib(default=lambda tokens: tokens, cmp=False, repr=False)
     is_archive = attr.ib(default=False, cmp=False)
     id = attr.ib(init=False)
@@ -125,6 +125,10 @@ class Submission:
     def __attrs_post_init__(self):
         object.__setattr__(self, "files", tuple(
             [File(pathlib.Path(path), self) for path in self.files]))
+        object.__setattr__(self, "large_files", tuple(
+            [File(pathlib.Path(path), self) for path in self.large_files]))
+        object.__setattr__(self, "undecodable_files", tuple(
+            [File(pathlib.Path(path), self) for path in self.undecodable_files]))
         object.__setattr__(self, "id", Submission._store[self])
 
     def __iter__(self):

--- a/compare50/_data.py
+++ b/compare50/_data.py
@@ -116,8 +116,8 @@ class Submission:
 
     path = attr.ib(converter=pathlib.Path, cmp=False)
     files = attr.ib(cmp=False)
-    large_files = attr.ib(default=attr.Factory(tuple), cmp=False, repr=False)
-    undecodable_files = attr.ib(default=attr.Factory(tuple), cmp=False, repr=False)
+    large_files = attr.ib(default=attr.Factory(tuple), converter=tuple, cmp=False, repr=False)
+    undecodable_files = attr.ib(default=attr.Factory(tuple), converter=tuple, cmp=False, repr=False)
     preprocessor = attr.ib(default=lambda tokens: tokens, cmp=False, repr=False)
     is_archive = attr.ib(default=False, cmp=False)
     id = attr.ib(init=False)

--- a/compare50/_data.py
+++ b/compare50/_data.py
@@ -116,8 +116,8 @@ class Submission:
 
     path = attr.ib(converter=pathlib.Path, cmp=False)
     files = attr.ib(cmp=False)
-    large_files = attr.ib(default=attr.Factory(tuple), converter=tuple, cmp=False, repr=False)
-    undecodable_files = attr.ib(default=attr.Factory(tuple), converter=tuple, cmp=False, repr=False)
+    large_files = attr.ib(default=attr.Factory(tuple), converter=lambda fs: tuple(pathlib.Path(f) for f in fs), cmp=False, repr=False)
+    undecodable_files = attr.ib(default=attr.Factory(tuple), converter=lambda fs: tuple(pathlib.Path(f) for f in fs), cmp=False, repr=False)
     preprocessor = attr.ib(default=lambda tokens: tokens, cmp=False, repr=False)
     is_archive = attr.ib(default=False, cmp=False)
     id = attr.ib(init=False)
@@ -125,10 +125,6 @@ class Submission:
     def __attrs_post_init__(self):
         object.__setattr__(self, "files", tuple(
             [File(pathlib.Path(path), self) for path in self.files]))
-        object.__setattr__(self, "large_files", tuple(
-            [pathlib.Path(path) for path in self.large_files]))
-        object.__setattr__(self, "undecodable_files", tuple(
-            [pathlib.Path(path) for path in self.undecodable_files]))
         object.__setattr__(self, "id", Submission._store[self])
 
     def __iter__(self):

--- a/compare50/_data.py
+++ b/compare50/_data.py
@@ -99,6 +99,15 @@ class IdStore(Mapping):
         return len(self.objects)
 
 
+def _to_path_tuple(fs):
+    """
+    Convert iterable yielding strings to tuple containing paths.
+    Ideally we could use an attrs converter decorator,but it doesn't exist yet
+    https://github.com/python-attrs/attrs/pull/404
+    """
+    return tuple(map(pathlib.Path, fs))
+
+
 @attr.s(slots=True, frozen=True)
 class Submission:
     """
@@ -116,11 +125,12 @@ class Submission:
 
     path = attr.ib(converter=pathlib.Path, cmp=False)
     files = attr.ib(cmp=False)
-    large_files = attr.ib(factory=tuple, converter=lambda fs: tuple(pathlib.Path(f) for f in fs), cmp=False, repr=False)
-    undecodable_files = attr.ib(factory=tuple, converter=lambda fs: tuple(pathlib.Path(f) for f in fs), cmp=False, repr=False)
+    large_files = attr.ib(factory=tuple, converter=_to_path_tuple, cmp=False, repr=False)
+    undecodable_files = attr.ib(factory=tuple, converter=_to_path_tuple, cmp=False, repr=False)
     preprocessor = attr.ib(default=lambda tokens: tokens, cmp=False, repr=False)
     is_archive = attr.ib(default=False, cmp=False)
     id = attr.ib(init=False)
+
 
     def __attrs_post_init__(self):
         object.__setattr__(self, "files", tuple(
@@ -134,6 +144,10 @@ class Submission:
     def get(cls, id):
         """Retrieve submission corresponding to specified id"""
         return cls._store.objects[id]
+
+    @staticmethod
+    def _to_path_tuple(fs):
+        return tuple(map(pathlib.Path, fs))
 
 
 @attr.s(slots=True, frozen=True)

--- a/compare50/_data.py
+++ b/compare50/_data.py
@@ -112,7 +112,7 @@ class Submission:
     Represents a single submission. Submissions may either be single files or
     directories containing many files.
     """
-    _store = IdStore(key=lambda sub: (sub.path, sub.files, sub.large_files, sub.undecodable_files))
+    _store = IdStore(key=lambda sub: (sub.path, sub.files))
 
     path = attr.ib(converter=pathlib.Path, cmp=False)
     files = attr.ib(cmp=False)
@@ -125,10 +125,6 @@ class Submission:
     def __attrs_post_init__(self):
         object.__setattr__(self, "files", tuple(
             [File(pathlib.Path(path), self) for path in self.files]))
-        object.__setattr__(self, "large_files", tuple(
-            [File(pathlib.Path(path), self) for path in self.large_files]))
-        object.__setattr__(self, "undecodable_files", tuple(
-            [File(pathlib.Path(path), self) for path in self.undecodable_files]))
         object.__setattr__(self, "id", Submission._store[self])
 
     def __iter__(self):

--- a/compare50/_data.py
+++ b/compare50/_data.py
@@ -112,7 +112,7 @@ class Submission:
     Represents a single submission. Submissions may either be single files or
     directories containing many files.
     """
-    _store = IdStore(key=lambda sub: (sub.path, sub.files))
+    _store = IdStore(key=lambda sub: (sub.path, sub.files, sub.large_files, sub.undecodable_files))
 
     path = attr.ib(converter=pathlib.Path, cmp=False)
     files = attr.ib(cmp=False)
@@ -125,6 +125,10 @@ class Submission:
     def __attrs_post_init__(self):
         object.__setattr__(self, "files", tuple(
             [File(pathlib.Path(path), self) for path in self.files]))
+        object.__setattr__(self, "large_files", tuple(
+            [pathlib.Path(path) for path in self.large_files]))
+        object.__setattr__(self, "undecodable_files", tuple(
+            [pathlib.Path(path) for path in self.undecodable_files]))
         object.__setattr__(self, "id", Submission._store[self])
 
     def __iter__(self):

--- a/compare50/_data.py
+++ b/compare50/_data.py
@@ -145,10 +145,6 @@ class Submission:
         """Retrieve submission corresponding to specified id"""
         return cls._store.objects[id]
 
-    @staticmethod
-    def _to_path_tuple(fs):
-        return tuple(map(pathlib.Path, fs))
-
 
 @attr.s(slots=True, frozen=True)
 class File:

--- a/tests/main_tests.py
+++ b/tests/main_tests.py
@@ -27,11 +27,11 @@ class TestSubmissionFactory(TestCase):
         api._progress_bar.close()
         api._progress_bar = None
 
-
     def test_no_submissions(self):
         preprocessor = lambda tokens : tokens
         os.mkdir("foo")
         subs = self.factory.get_all(["foo"], preprocessor)
+        subs = {sub for sub in subs if sub.files}
         self.assertEqual(subs, set())
 
     def test_one_submission(self):
@@ -42,10 +42,12 @@ class TestSubmissionFactory(TestCase):
             pass
 
         subs = list(self.factory.get_all(["foo"], preprocessor))
+        subs = [sub for sub in subs if sub.files]
         self.assertEqual(len(subs), 1)
         self.assertEqual(subs[0].path.name, "foo")
 
         subs = list(self.factory.get_all(["foo/bar"], preprocessor))
+        subs = [sub for sub in subs if sub.files]
         self.assertEqual(len(subs), 1)
         self.assertEqual(subs[0].path.parent.name, "foo")
         self.assertEqual(subs[0].path.name, "bar")
@@ -58,6 +60,7 @@ class TestSubmissionFactory(TestCase):
             pass
 
         subs = list(self.factory.get_all(["foo"], preprocessor))
+        subs = [sub for sub in subs if sub.files]
         self.assertEqual(subs[0].preprocessor(""), ["foo"])
 
     def test_single_file_submission(self):
@@ -67,6 +70,7 @@ class TestSubmissionFactory(TestCase):
             pass
 
         subs = list(self.factory.get_all(["foo/bar.py"], preprocessor))
+        subs = [sub for sub in subs if sub.files]
         self.assertEqual(len(subs), 1)
         self.assertEqual(len(list(subs[0].files)), 1)
         self.assertEqual(str(list(subs[0].files)[0].name), "bar.py")
@@ -79,6 +83,7 @@ class TestSubmissionFactory(TestCase):
 
         self.factory.exclude("*")
         subs = self.factory.get_all(["foo"], preprocessor)
+        subs = {sub for sub in subs if sub.files}
         self.assertEquals(subs, set())
 
     def test_include_pattern(self):
@@ -90,6 +95,7 @@ class TestSubmissionFactory(TestCase):
         self.factory.exclude("*")
         self.factory.include("bar.py")
         subs = list(self.factory.get_all(["foo"], preprocessor))
+        subs = [sub for sub in subs if sub.files]
         self.assertEqual(len(subs), 1)
         self.assertEqual(len(list(subs[0].files)), 1)
         self.assertEqual(str(list(subs[0].files)[0].name), "bar.py")
@@ -101,6 +107,7 @@ class TestSubmissionFactory(TestCase):
             f.write(b'\x80abc')
 
         subs = self.factory.get_all(["foo"], preprocessor)
+        subs = {sub for sub in subs if sub.files}
         self.assertEqual(subs, set())
 
 


### PR DESCRIPTION
`SubmissionFactory` now has a `max_file_size` attribute that removes any files bigger than that. This is configurable via a cmdline option `--max-file-size`:

![image](https://user-images.githubusercontent.com/1257775/79897716-63f8a380-840a-11ea-80ac-3e300360535a.png)

Besides this, a `Submission` now keeps track of `undecodable_files` and `large_files`, allowing compare50 to print how many files are excluded for those reasons:

![image](https://user-images.githubusercontent.com/1257775/79897290-c7ce9c80-8409-11ea-929e-3306acbb2c15.png)

And, by setting `-v` or `--verbose`, compare50 can now print out all files that it excluded because of the above reasons:

![image](https://user-images.githubusercontent.com/1257775/79897433-05cbc080-840a-11ea-8459-9d04af4879d8.png)

Side note on the implementation, I figured the more prominent reason for exclusion is that a file is non utf-8. So compare50 checks that first even though it's more costly to check that than the file size. This way compare50 does not report `kareem.mp4` as too large, but rather as a non utf-8 file.

Files can be excluded through a third option, the `--exclude` flag. I decided not to implement the same printing functionality for this, as this is something you control and set yourself, and implementing this would make compare50 even more verbose. 
However, I can see the use case for compare50 telling you exactly which submissions and files therein made the cut and which didn't. But I'd vote we'd implement a flag like `--dry-run` or `--stats` that just dumps all this to the screen without consequently running the comparison. Any thoughts on this?