### PR TITLE
Issues 55 and 59

### DIFF
--- a/compare50/_renderer/static/match.css
+++ b/compare50/_renderer/static/match.css
@@ -74,6 +74,10 @@ pre {
     counter-reset: none;
 }
 
+.file_name {
+    word-break: break-word;
+}
+
 /* highlighted code fragments */
 .match {
     background-color: #ffd0a8;
@@ -135,7 +139,7 @@ pre {
     margin-bottom: 10%;
 }
 
-#next_group {
+.matches_group {
     margin-bottom: .4em;
 }
 

--- a/compare50/_renderer/static/match.js
+++ b/compare50/_renderer/static/match.js
@@ -215,52 +215,27 @@ function init_group_button(groups, view_name) {
     }
 
     // init group counter
-    let group_index = 0;
-    update_group_counter();
+    let group_index = -1;
+    go_to_adjacent_group(new Event("InitializeHighlights"), 1);
 
-    // keep track of last move for wrapping's sake
-    let last_move = null;
-
-    function go_to_adjacent_group(event, direction=null) {
+    function go_to_adjacent_group(event, direction) {
         // if view is not active (current), nothing to do here
         if (CURRENT_VIEW !== view_name) {
             return;
         }
 
-        // find direction from event target (when a button, not keypress)
-        if (direction === null) {
-            direction = (event.target.id == "next_group") ? "n" : "p";
+        // increment index
+        group_index += direction;
+
+        // wrap around
+        if (group_index >= sorted_groups.length) {
+            group_index = 0;
         }
-
-        // different index behavior if going to next or previous group
-        if (direction == "n") {
-            if (last_move == "p") {
-                group_index += 1;
-            }
-            if (group_index < 0) {
-                group_index = 0;
-            }
-
-            index_increment = 1;
-        }
-        else {
-            if (group_index == 0 && last_move == "n") {
-                // if on last group right now
-                group_index = sorted_groups.length - 2;
-            }
-            else if (group_index < 0 && last_move != "n") {
-                // if on first group right now
-                group_index = sorted_groups.length - 1;
-            }
-            else if (last_move == "n") {
-                group_index -= 1;
-            }
-
-            index_increment = -1;
+        else if (group_index < 0) {
+            group_index = sorted_groups.length - 1;
         }
 
         update_group_counter();
-        last_move = direction;
 
         // find first fragment of group
         let frag = sorted_groups[group_index].spans[0].fragments[0];
@@ -277,29 +252,30 @@ function init_group_button(groups, view_name) {
 
         // scroll to frag
         frag.scroll_to();
-
-        // increment index
-        group_index = (group_index + index_increment) % sorted_groups.length;
     }
 
     // On click move to next group from sorted_groups
     let next_group_button = document.getElementById("next_group");
-    next_group_button.addEventListener("click", go_to_adjacent_group);
+    next_group_button.addEventListener("click", (event) => {
+        go_to_adjacent_group(event, 1);
+    });
     document.addEventListener("keyup", (event) =>  {
-        if (event.key === ' ' || event.key == "ArrowRight") {
+        if (event.key === ' ' || event.key == "]") {
             event.preventDefault();
-            go_to_adjacent_group(event, "n"); 
+            go_to_adjacent_group(event, 1); 
         }
     });
 
     // On click move to previous group from sorted_groups
     let previous_group_button = document.getElementById("previous_group");
-    previous_group_button.addEventListener("click", go_to_adjacent_group);
+    previous_group_button.addEventListener("click", (event) => {
+        go_to_adjacent_group(event, -1);
+    });
     document.addEventListener("keyup", (event) =>  {
-        // left arrow key will go to previous group
-        if (event.key === "ArrowLeft") {
+        // left bracket key will go to previous group
+        if (event.key === "[") {
             event.preventDefault();
-            go_to_adjacent_group(event, "p");
+            go_to_adjacent_group(event, -1);
         }
     });
 }

--- a/compare50/_renderer/static/match.js
+++ b/compare50/_renderer/static/match.js
@@ -178,8 +178,8 @@ function init_navigation(id) {
 }
 
 function init_group_button(groups, view_name) {
-    function update_group_counter(mult=1) {
-        document.getElementById("group_counter").innerHTML = (group_index + mult * 1) + " / " + groups.length;
+    function update_group_counter() {
+        document.getElementById("group_counter").innerHTML = (group_index + 1) + " / " + groups.length;
     }
 
     // If view changed, update group counter
@@ -227,26 +227,35 @@ function init_group_button(groups, view_name) {
             return;
         }
 
+        // find direction from event target (when a button, not keypress)
         if (direction === null) {
             direction = (event.target.id == "next_group") ? "n" : "p";
         }
 
+        // different index behavior if going to next or previous group
         if (direction == "n") {
+            if (last_move == "p") {
+                group_index += 1;
+            }
             if (group_index < 0) {
                 group_index = 0;
             }
+
             index_increment = 1;
         }
         else {
             if (group_index == 0 && last_move == "n") {
+                // if on last group right now
                 group_index = sorted_groups.length - 2;
             }
             else if (group_index < 0 && last_move != "n") {
+                // if on first group right now
                 group_index = sorted_groups.length - 1;
             }
             else if (last_move == "n") {
                 group_index -= 1;
             }
+
             index_increment = -1;
         }
 
@@ -279,7 +288,7 @@ function init_group_button(groups, view_name) {
     document.addEventListener("keyup", (event) =>  {
         if (event.key === ' ') {
             event.preventDefault();
-            go_to_next_group(event, "n"); 
+            go_to_adjacent_group(event, "n"); 
         }
     });
 
@@ -287,7 +296,8 @@ function init_group_button(groups, view_name) {
     let previous_group_button = document.getElementById("previous_group");
     previous_group_button.addEventListener("click", go_to_adjacent_group);
     document.addEventListener("keyup", (event) =>  {
-        if (event.key === 8) {
+        // left arrow key will go to previous group
+        if (event.key === "ArrowLeft") {
             event.preventDefault();
             go_to_adjacent_group(event, "p");
         }

--- a/compare50/_renderer/static/match.js
+++ b/compare50/_renderer/static/match.js
@@ -178,8 +178,8 @@ function init_navigation(id) {
 }
 
 function init_group_button(groups, view_name) {
-    function update_group_counter() {
-        document.getElementById("group_counter").innerHTML = (group_index + 1) + " / " + groups.length;
+    function update_group_counter(mult=1) {
+        document.getElementById("group_counter").innerHTML = (group_index + mult * 1) + " / " + groups.length;
     }
 
     // If view changed, update group counter
@@ -218,13 +218,40 @@ function init_group_button(groups, view_name) {
     let group_index = 0;
     update_group_counter();
 
-    function go_to_next_group(event) {
+    // keep track of last move for wrapping's sake
+    let last_move = null;
+
+    function go_to_adjacent_group(event, direction=null) {
         // if view is not active (current), nothing to do here
         if (CURRENT_VIEW !== view_name) {
             return;
         }
 
+        if (direction === null) {
+            direction = (event.target.id == "next_group") ? "n" : "p";
+        }
+
+        if (direction == "n") {
+            if (group_index < 0) {
+                group_index = 0;
+            }
+            index_increment = 1;
+        }
+        else {
+            if (group_index == 0 && last_move == "n") {
+                group_index = sorted_groups.length - 2;
+            }
+            else if (group_index < 0 && last_move != "n") {
+                group_index = sorted_groups.length - 1;
+            }
+            else if (last_move == "n") {
+                group_index -= 1;
+            }
+            index_increment = -1;
+        }
+
         update_group_counter();
+        last_move = direction;
 
         // find first fragment of group
         let frag = sorted_groups[group_index].spans[0].fragments[0];
@@ -243,16 +270,26 @@ function init_group_button(groups, view_name) {
         frag.scroll_to();
 
         // increment index
-        group_index = (group_index + 1) % sorted_groups.length;
-
+        group_index = (group_index + index_increment) % sorted_groups.length;
     }
+
     // On click move to next group from sorted_groups
     let next_group_button = document.getElementById("next_group");
-    next_group_button.addEventListener("click", go_to_next_group);
+    next_group_button.addEventListener("click", go_to_adjacent_group);
     document.addEventListener("keyup", (event) =>  {
         if (event.key === ' ') {
-            event.preventDefault()
-            go_to_next_group(event); 
+            event.preventDefault();
+            go_to_next_group(event, "n"); 
+        }
+    });
+
+    // On click move to previous group from sorted_groups
+    let previous_group_button = document.getElementById("previous_group");
+    previous_group_button.addEventListener("click", go_to_adjacent_group);
+    document.addEventListener("keyup", (event) =>  {
+        if (event.key === 8) {
+            event.preventDefault();
+            go_to_adjacent_group(event, "p");
         }
     });
 }

--- a/compare50/_renderer/static/match.js
+++ b/compare50/_renderer/static/match.js
@@ -286,7 +286,7 @@ function init_group_button(groups, view_name) {
     let next_group_button = document.getElementById("next_group");
     next_group_button.addEventListener("click", go_to_adjacent_group);
     document.addEventListener("keyup", (event) =>  {
-        if (event.key === ' ') {
+        if (event.key === ' ' || event.key == "ArrowRight") {
             event.preventDefault();
             go_to_adjacent_group(event, "n"); 
         }

--- a/compare50/_renderer/templates/match_page.html
+++ b/compare50/_renderer/templates/match_page.html
@@ -27,8 +27,11 @@
                 {% endfor %}
                 </div>
                 <div id="group_nav">
-                  <button type="button" class="btn btn-outline-light next_group" id="next_group">next</button>
-                  <div class="text-light" id="group_counter"></div>
+                    <div class="btn-group" role="group" aria-label="NextPrevGroup">
+                        <button type="button" class="btn btn-outline-light matches_group" id="previous_group">&lt;</button>
+                        <button type="button" class="btn btn-outline-light matches_group" id="next_group">&gt;</button>
+                    </div>
+                    <div class="text-light" id="group_counter"></div>
                 </div>
             </nav>
             <div id="content">


### PR DESCRIPTION
Resolves #55 by adding a CSS rule to `.file_name`.


Resolves #59 by changing `go_to_next_group` to a more abstracted function called `go_to_adjacent_group`. This function takes in a direction, "n" (next) or "p" (previous) as an optional argument (used for key presses), and will attempt to discern the direction from the event target's ID if not provided (as in the case where the event is called from a click event handler).

Adds a variable on the same scope as `group_index` called `last_move`, to keep track of whether the last move was to the next or previous group (this is due to the existing design of how `group_index` is incremented; I needed a way to account for whether the `group_index` we're moving to is 0 because we were on the last element using the Next button, or because we're moving to the previous group and should actually go there).

Adds a variable scoped under `go_to_adjacent_group` called `index_increment` which determines whether we should increment `group_index` positively (in the case of next button) or negatively (previous button). I reasoned that this was cleaner than incorporating a ternary conditional into the existing one-liner for incrementing `group_index`.

Adds a button to `match_page.html` for the next group button. This is within a new btn-group; previous `#next_group` styling was changed to `.matches_group` so as to provide the same for both buttons.

Adds an event listener on the left arrow key to move to the previous group. Did not change the existing space bar event listener to move to the next one, but for consistency also added a right arrow key event listener to move to the next group.

I wasn't sure about the style standards for JS in this repo, but using braces even for one-line conditional predicates seemed to be the norm, so I did that. Looking forward to any feedback you may have.