### PR TITLE
convert => converter

### DIFF
--- a/compare50/_renderer/_renderer.py
+++ b/compare50/_renderer/_renderer.py
@@ -18,8 +18,8 @@ TEMPLATES = pathlib.Path(pkg_resources.resource_filename("compare50._renderer", 
 
 @attr.s(slots=True)
 class Fragment:
-    content = attr.ib(convert=lambda c: tuple(c.splitlines(True)))
-    spans = attr.ib(default=attr.Factory(tuple), convert=tuple)
+    content = attr.ib(converter=lambda c: tuple(c.splitlines(True)))
+    spans = attr.ib(default=attr.Factory(tuple), converter=tuple)
 
 
 @attr.s(slots=True)

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(
     packages=find_packages(exclude=["tests"]),
     scripts=["bin/compare50"],
     url="https://github.com/cs50/compare50",
-    version="1.2.1",
+    version="1.2.2",
     include_package_data=True,
 )


### PR DESCRIPTION
The `convert` keyword in `attr.ib` was deprecated and got replaced by the `converter`: https://github.com/python-attrs/attrs/blob/master/CHANGELOG.rst#backward-incompatible-changes-2

Only the wording changed: https://github.com/python-attrs/attrs/issues/307
