### PR TITLE
include ignored_files in ignored_index, dont render if no scores

### DIFF
--- a/compare50/__main__.py
+++ b/compare50/__main__.py
@@ -424,6 +424,11 @@ def main():
             # Cross compare and rank all submissions, keep only top `n`
             scores = _api.rank(subs, archive_subs, ignored_files, passes[0], n=args.n)
 
+        # If ranking produced no scores, there are no matches, stop
+        if not scores:
+            termcolor.cprint(f"Done, no similarities found.", "yellow")
+            return
+
         # Get the matching spans, group them per submission
         groups = []
         pass_to_results = {}

--- a/compare50/comparators/_winnowing.py
+++ b/compare50/comparators/_winnowing.py
@@ -42,6 +42,7 @@ class Winnowing(Comparator):
         bar.reset(total=math.ceil((len(submission_files) + len(archive_files) + len(ignored_files)) / 0.9))
         frequency_map = collections.Counter()
         with _api.Executor() as executor:
+            
             # Subs and archive subs
             for index, files in ((submission_index, submission_files), (archive_index, archive_files)):
                 for idx in executor.map(self._index_file(ScoreIndex, (self.k, self.t)), files):
@@ -49,11 +50,11 @@ class Winnowing(Comparator):
                         frequency_map[hash_] += 1
                     index.include_all(idx)
                     bar.update()
+            
             # Ignored files
             for idx in executor.map(self._index_file(ScoreIndex, (self.k, self.t)), ignored_files):
-                index.include_all(idx)
+                ignored_index.include_all(idx)
                 bar.update()
-
 
         submission_index.ignore_all(ignored_index)
         archive_index.ignore_all(ignored_index)


### PR DESCRIPTION
Arturo ran into a bug with distro files showing up in the results. Turns out compare50 was including the distro files in the index for normal files instead. compare50 did however correctly filter the distro code out of the shown results. This patch doesn't have any real effect on scores because the Inverse Document Frequency makes the distro matches irrelevant. It does however prevent distro files from showing up in the results!