### PR TITLE
Infer lexers on *.txt files and warn on plaintext

### DIFF
--- a/compare50/_data.py
+++ b/compare50/_data.py
@@ -184,20 +184,22 @@ class File:
     def lexer(self):
         """Determine which Pygments lexer should be used."""
         def read_and_guess_lexer():
+            """Reads a file, guesses an appropriate lexer. Fallback to plaintext."""
             try:
                 return pygments.lexers.guess_lexer(self.read())
             except pygments.util.ClassNotFound:
                 return pygments.lexers.special.TextLexer()
 
         ext = self.name.suffix
-        try:
-            return self._lexer_cache[ext]
-        except KeyError:
-            pass
 
         # if this is a txt file, assume its some kind of code and infer its lexer
         if ext == '.txt':
             return read_and_guess_lexer()
+
+        try:
+            return self._lexer_cache[ext]
+        except KeyError:
+            pass
 
         # get lexer for this file type
         try:
@@ -216,10 +218,6 @@ class File:
         """Get the raw tokens of the file."""
         text  = self.read()
         lexer = self.lexer()
-        if lexer is None:
-            import termcolor
-            termcolor.cprint(f"{self.name.name} appears to be a plaintext file. Skipping.")
-            return []
         lexer_tokens = lexer.get_tokens_unprocessed(text)
         tokens = []
         prevToken = None

--- a/compare50/_data.py
+++ b/compare50/_data.py
@@ -217,8 +217,7 @@ class File:
     def unprocessed_tokens(self):
         """Get the raw tokens of the file."""
         text  = self.read()
-        lexer = self.lexer()
-        lexer_tokens = lexer.get_tokens_unprocessed(text)
+        lexer_tokens = lexer.lexer().get_tokens_unprocessed(text)
         tokens = []
         prevToken = None
         for token in lexer_tokens:

--- a/compare50/_data.py
+++ b/compare50/_data.py
@@ -217,7 +217,7 @@ class File:
     def unprocessed_tokens(self):
         """Get the raw tokens of the file."""
         text  = self.read()
-        lexer_tokens = lexer.lexer().get_tokens_unprocessed(text)
+        lexer_tokens = self.lexer().get_tokens_unprocessed(text)
         tokens = []
         prevToken = None
         for token in lexer_tokens:


### PR DESCRIPTION
Related to #78.

Instead of just assuming that *.txt files are plaintext, assume that the *.txt file is made up of some specific language. Infer that language using `pygment`'s `guess_lexer()`, and use that as the lexer.

Warns the user when a *.txt file is being interpreted as a coding language. Warns the user that plaintext files are not well supported with `structure`.

<img width="1336" height="406" alt="image" src="https://github.com/user-attachments/assets/29999920-b813-48af-920a-050ff34be8a2" />
