### PR TITLE
Added custom WordLexer for .txt files

### DIFF
--- a/compare50/_data.py
+++ b/compare50/_data.py
@@ -1,13 +1,11 @@
 import abc
 from collections.abc import Mapping, Sequence
-import os
 import pathlib
 import numbers
 
 import attr
 import pygments
 import pygments.lexers
-
 from .lexers import WordLexer
 
 

--- a/compare50/_data.py
+++ b/compare50/_data.py
@@ -8,6 +8,8 @@ import attr
 import pygments
 import pygments.lexers
 
+from .lexers import WordLexer
+
 
 __all__ = ["Pass", "Comparator", "File", "Submission",
            "Pass", "Span", "Score", "Comparison", "Token"]
@@ -191,14 +193,18 @@ class File:
 
         # get lexer for this file type
         try:
-            lexer = pygments.lexers.get_lexer_for_filename(self.name.name)
+            if ext == ".txt":
+                lexer = WordLexer()
+            else:
+                lexer = pygments.lexers.get_lexer_for_filename(self.name.name)
+    
             self._lexer_cache[ext] = lexer
             return lexer
         except pygments.util.ClassNotFound:
             try:
                 return pygments.lexers.guess_lexer(self.read())
             except pygments.util.ClassNotFound:
-                return pygments.lexers.special.TextLexer()
+                return WordLexer()
 
     @classmethod
     def get(cls, id):

--- a/compare50/lexers.py
+++ b/compare50/lexers.py
@@ -1,0 +1,16 @@
+from pygments.lexer import RegexLexer
+from pygments.token import Text, Name
+
+class WordLexer(RegexLexer):
+    """Custom compare50 lexer that creates a token based on each 'word'."""
+    name = "WordLexer"
+    aliases = ["word"]
+    filenames = ["*.txt"]
+
+    tokens = {
+        "root": [
+            (r"\s+", Text),           # whitespace
+            (r"\w+", Name),           # word (alphanumeric)
+            (r"\W", Text),            # punctuation or other
+        ]
+    }


### PR DESCRIPTION
An alternative solution to #78 and #99.

See PR #119 for the original solution.

Now, `.txt` files will use our custom `WordLexer`. A word is considered any continuous stream of letters, digits, or underscores, uninterrupted by any punctuation or whitespace. Based off of `pygment`'s `RegexLexer`.

Removes support for `pygment`'s `TextLexer`.